### PR TITLE
Fix Null Row calculations (#166)

### DIFF
--- a/dataprofiler/profilers/utils.py
+++ b/dataprofiler/profilers/utils.py
@@ -95,7 +95,6 @@ def shuffle_in_chunks(data_length, chunk_size):
         except ValueError as e:
             warnings.warn("Seed should be an integer", RuntimeWarning)
 
-
     indices = KeyDict()
     j = 0
     
@@ -105,12 +104,10 @@ def shuffle_in_chunks(data_length, chunk_size):
         # determine the chunk size and preallocate an array
         true_chunk_size = min(chunk_size, data_length - chunk_size * chunk_ind)
         values = [-1] * true_chunk_size
-
         
-        # Generate random list of indicies         
+        # Generate random list of indices
         lower_bound_list = np.array(range(j, j + true_chunk_size))
         random_list = rng.integers(lower_bound_list, data_length)
-
 
         # shuffle the indexes
         for count in range(true_chunk_size):


### PR DESCRIPTION
* Some initial spacing and spelling fixes

* Update base_stats to keep track of ids sampled, and store in StructuredDataProfile, to be used in Profiler._update_row_statistics by taking min of all samples used in each column

* Update Profile merge to accomodate for new base_stats

* Added default to min calculation

* Found reason for ValueError with sample_ids, fixed it

* Implimented null row index trimming by min sampled id, no test written yet

* Added back default

* Fixed np shape errors, changed some naming, one test still fails (not errors, just failed assertion)

* Fix sample_ids to actually use index rather than integer positions

* Added test case, changed equals in clean_data that was causing multiple updates to occur even when not necessary

* Fixed test comment

* Committing before a merge

* Hit dat reset. Instead of passing every single sample id around, instead just calculate at update_from_chunk what min sampled col is, and reach into sample ids generated there to determine what ids to use

* Whoops, forgot to intersect relative to index, not just id

* Make null ratios use rows sampled not max col sample

* Make complete row ids a list

* Move attribute initialization out of update into init

* Fix +1 indexing issue

* Fix mock issue

* Added test case with null rows